### PR TITLE
Add recommendation quiz modal

### DIFF
--- a/docs/assets/css/kits.css
+++ b/docs/assets/css/kits.css
@@ -141,3 +141,49 @@ html[data-theme='dark'] .filters button {
 .accordion-item.open p {
   display: block;
 }
+
+/* Quiz modal overlay */
+#quizModal {
+  position: fixed;
+  inset: 0;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0,0,0,.6);
+  z-index: 1200;
+}
+#quizModal.active { display: flex; }
+#quizModal .modal-content {
+  background: var(--card);
+  color: var(--text-primary);
+  padding: 2rem;
+  border-radius: var(--radius);
+  position: relative;
+  width: 90%;
+  max-width: 500px;
+}
+#quizModal .modal-close {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  background: none;
+  border: none;
+  font-size: 1.5rem;
+  color: var(--text-primary);
+  cursor: pointer;
+}
+#quizModal label {
+  display: block;
+  margin-top: 1rem;
+}
+#quizModal select {
+  width: 100%;
+  margin-top: .25rem;
+  padding: .5rem;
+}
+#quizModal .modal-actions {
+  margin-top: 1.5rem;
+  display: flex;
+  gap: 1rem;
+  justify-content: flex-end;
+}

--- a/docs/assets/js/kits.js
+++ b/docs/assets/js/kits.js
@@ -8,6 +8,8 @@ const elements = {
   access: document.getElementById('accessFilter'),
   speed: document.getElementById('speedFilter'),
   mesh: document.getElementById('meshFilter'),
+  device: document.getElementById('deviceFilter'),
+  usage: document.getElementById('usageFilter'),
   results: document.getElementById('kitResults')
 };
 
@@ -28,12 +30,16 @@ function applyFilters() {
   const access = elements.access.value;
   const speed = parseInt(elements.speed.value, 10);
   const mesh = elements.mesh.value === 'mesh';
+  const device = elements.device ? elements.device.value : '';
+  const usage = elements.usage ? elements.usage.value : '';
 
   if (wifi) res = res.filter(k => k.wifiStandard === wifi);
   if (env) res = res.filter(k => k.environmentPreset === env);
   if (access) res = res.filter(k => k.accessSupport.includes(access));
   if (!isNaN(speed)) res = res.filter(k => k.maxWanSpeedMbps >= speed);
   if (mesh) res = res.filter(k => k.meshReady);
+  if (device) res = res.filter(k => k.deviceLoad ? k.deviceLoad === device : true);
+  if (usage) res = res.filter(k => k.primaryUse ? k.primaryUse.includes(usage) : true);
 
   res = [...res].sort((a, b) => a.priceUsd - b.priceUsd);
 
@@ -52,8 +58,8 @@ const STORE_KEY = 'rh-kit-filters';
 
 function saveFilters() {
   const data = {};
-  ['wifi','env','access','speed','mesh'].forEach(k => {
-    data[k] = elements[k].value;
+  ['wifi','env','access','speed','mesh','device','usage'].forEach(k => {
+    if (elements[k]) data[k] = elements[k].value;
   });
   localStorage.setItem(STORE_KEY, JSON.stringify(data));
 }
@@ -63,8 +69,8 @@ function loadFilters() {
   if (saved) {
     try {
       const data = JSON.parse(saved);
-      ['wifi','env','access','speed','mesh'].forEach(k => {
-        if (data[k] !== undefined) elements[k].value = data[k];
+      ['wifi','env','access','speed','mesh','device','usage'].forEach(k => {
+        if (data[k] !== undefined && elements[k]) elements[k].value = data[k];
       });
     } catch(e) {}
   }
@@ -82,14 +88,18 @@ async function init() {
   }
 }
 
-['wifi','env','access','speed','mesh'].forEach(id =>
-  elements[id].addEventListener('change', () => { saveFilters(); applyFilters(); })
-);
+['wifi','env','access','speed','mesh','device','usage'].forEach(id => {
+  if (elements[id]) {
+    elements[id].addEventListener('change', () => { saveFilters(); applyFilters(); });
+  }
+});
 
 const clearBtn = document.getElementById('clearFilters');
 if (clearBtn) {
   clearBtn.addEventListener('click', () => {
-    ['wifi','env','access','speed','mesh'].forEach(k => elements[k].value = '');
+    ['wifi','env','access','speed','mesh','device','usage'].forEach(k => {
+      if (elements[k]) elements[k].value = '';
+    });
     localStorage.removeItem(STORE_KEY);
     applyFilters();
   });

--- a/docs/assets/js/quiz-modal.js
+++ b/docs/assets/js/quiz-modal.js
@@ -1,0 +1,90 @@
+"use strict";
+
+document.addEventListener('DOMContentLoaded', () => {
+  const openBtn = document.getElementById('startQuizBtn');
+  const modal = document.getElementById('quizModal');
+  const form = document.getElementById('quizForm');
+  const closeBtns = modal ? modal.querySelectorAll('.quiz-close') : [];
+  let focusables = [];
+  let firstFocus, lastFocus;
+
+  const envMap = {
+    'Apartment/Small': 'Apartment',
+    '2–3 Bedroom': 'House',
+    'Large/Multi-floor': 'House'
+  };
+
+  function ensureFilter(id, labelText, options) {
+    let select = document.getElementById(id);
+    if (!select) {
+      const aside = document.getElementById('kitFilterSection');
+      if (!aside) return null;
+      const clearBtn = document.getElementById('clearFilters');
+      const label = document.createElement('label');
+      label.setAttribute('for', id);
+      label.textContent = labelText;
+      select = document.createElement('select');
+      select.id = id;
+      select.innerHTML = '<option value="">Any</option>' +
+        options.map(o => `<option value="${o}">${o}</option>`).join('');
+      aside.insertBefore(label, clearBtn);
+      aside.insertBefore(select, clearBtn);
+    }
+    return select;
+  }
+
+  function trapFocus(e) {
+    if (e.key === 'Escape') {
+      closeModal();
+    } else if (e.key === 'Tab' && focusables.length) {
+      if (e.shiftKey && document.activeElement === firstFocus) {
+        e.preventDefault();
+        lastFocus.focus();
+      } else if (!e.shiftKey && document.activeElement === lastFocus) {
+        e.preventDefault();
+        firstFocus.focus();
+      }
+    }
+  }
+
+  function openModal() {
+    modal.classList.add('active');
+    document.body.style.overflow = 'hidden';
+    focusables = modal.querySelectorAll(
+      'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+    );
+    firstFocus = focusables[0];
+    lastFocus = focusables[focusables.length - 1];
+    firstFocus.focus();
+    document.addEventListener('keydown', trapFocus);
+  }
+
+  function closeModal() {
+    modal.classList.remove('active');
+    document.body.style.overflow = '';
+    document.removeEventListener('keydown', trapFocus);
+    if (openBtn) openBtn.focus();
+  }
+
+  if (openBtn && modal && form) {
+    openBtn.addEventListener('click', openModal);
+    closeBtns.forEach(btn => btn.addEventListener('click', closeModal));
+    modal.addEventListener('click', e => { if (e.target === modal) closeModal(); });
+
+    form.addEventListener('submit', e => {
+      e.preventDefault();
+      const home = form.quizHomeSize.value;
+      const devices = form.quizDeviceLoad.value;
+      const usage = form.quizPrimaryUse.value;
+
+      const envSelect = document.getElementById('envFilter');
+      if (envSelect) envSelect.value = envMap[home] || home;
+
+      ensureFilter('deviceFilter', 'Device Load', ['1–5','6–15','16+']).value = devices;
+      ensureFilter('usageFilter', 'Primary Use', ['Family Streaming','Gaming','Work-From-Home','Smart-Home','All-Purpose']).value = usage;
+
+      if (typeof applyFilters === 'function') applyFilters();
+      closeModal();
+    });
+  }
+});

--- a/docs/kits.html
+++ b/docs/kits.html
@@ -23,7 +23,41 @@
   <section class="hero">
     <h1>Find Your Perfect Kit</h1>
     <p>Explore our top router picks for home and professional networks.</p>
+    <div class="hero-actions">
+      <button id="startQuizBtn" class="btn" type="button">Start Recommendation</button>
+    </div>
   </section>
+
+  <div id="quizModal" class="quiz-modal">
+    <form id="quizForm" class="modal-content">
+      <button type="button" class="quiz-close modal-close" aria-label="Close">&times;</button>
+      <h2>Quick Quiz</h2>
+      <label for="quizHomeSize">Home Size</label>
+      <select id="quizHomeSize" name="quizHomeSize" required>
+        <option value="Apartment/Small">Apartment/Small</option>
+        <option value="2–3 Bedroom">2–3 Bedroom</option>
+        <option value="Large/Multi-floor">Large/Multi-floor</option>
+      </select>
+      <label for="quizDeviceLoad">Device Load</label>
+      <select id="quizDeviceLoad" name="quizDeviceLoad" required>
+        <option value="1–5">1–5</option>
+        <option value="6–15">6–15</option>
+        <option value="16+">16+</option>
+      </select>
+      <label for="quizPrimaryUse">Primary Use</label>
+      <select id="quizPrimaryUse" name="quizPrimaryUse" required>
+        <option value="Family Streaming">Family Streaming</option>
+        <option value="Gaming">Gaming</option>
+        <option value="Work-From-Home">Work-From-Home</option>
+        <option value="Smart-Home">Smart-Home</option>
+        <option value="All-Purpose">All-Purpose</option>
+      </select>
+      <div class="modal-actions">
+        <button type="submit" class="btn">Apply</button>
+        <button type="button" class="btn-secondary quiz-close">Close</button>
+      </div>
+    </form>
+  </div>
 
   <button id="filterToggle" class="filter-toggle" aria-expanded="false" aria-controls="kitFilterSection">Filters</button>
   <aside id="kitFilterSection" class="kit-filters filters lg:w-64 space-y-4 lg:sticky lg:top-24">
@@ -140,5 +174,6 @@
 
   <script src="scripts.js" defer></script>
   <script src="assets/js/kits.js" defer></script>
+  <script src="assets/js/quiz-modal.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a Start Recommendation button and quiz modal to kits.html
- insert new quiz-modal.js for quiz logic
- style modal in kits.css
- improve modal UX, dynamic filter insertion, and filter logic

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687f1280f4f4832fa5d1803d145ebd96